### PR TITLE
Fix avatar alignment and correct Phoenix version display

### DIFF
--- a/lib/demo_web/components/layouts.ex
+++ b/lib/demo_web/components/layouts.ex
@@ -34,7 +34,7 @@ defmodule DemoWeb.Layouts do
     <header class="navbar bg-base-100 shadow-sm border-b border-base-200 px-6">
       <div class="flex-1">
         <a href="/" class="flex items-center gap-3 hover:opacity-80 transition-opacity">
-          <div class="avatar placeholder">
+          <div class="avatar avatar-placeholder">
             <div class="bg-primary text-primary-content rounded-full w-10 h-10 flex items-center justify-center">
               <span class="text-lg font-bold">LT</span>
             </div>

--- a/lib/demo_web/controllers/page_html/home.html.heex
+++ b/lib/demo_web/controllers/page_html/home.html.heex
@@ -6,7 +6,7 @@
         <div class="max-w-3xl">
           <!-- Logo and Title -->
           <div class="flex items-center justify-center gap-4 mb-8">
-            <div class="avatar placeholder">
+            <div class="avatar avatar-placeholder">
               <div class="bg-primary text-primary-content rounded-full w-16 h-16 flex justify-center items-center">
                 <span class="text-2xl font-bold">LT</span>
               </div>
@@ -42,7 +42,7 @@
               <div class="stat-desc">Built-in capabilities</div>
             </div>
             <div class="stat">
-              <div class="stat-title">LiveView</div>
+              <div class="stat-title">Phoenix</div>
               <div class="stat-value text-accent">1.8+</div>
               <div class="stat-desc">Compatible</div>
             </div>


### PR DESCRIPTION
Replace incorrect 'avatar placeholder' with 'avatar avatar-placeholder'

Fix version display: Phoenix 1.8+ (not LiveView which is at RC 1.1)